### PR TITLE
Update comparison table for D, add some tweaks

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -34,13 +34,14 @@ I created V because none of the existing languages had all of the following
 features:
 
 <table>
-<tr><td style='width:300px'>Fast compilation<td style='width:200px'> Go, Delphi 
+<tr><td style='width:300px'>Fast compilation<td style='width:200px'> D, Go, Delphi 
 <tr><td>Simplicity & maintainability<td>Go
-<tr><td>Great performance on par with C and <br>zero cost C interop<td> C, C++, Delphi, Rust, Nim, Zig
-<tr><td>Safety (immutability, no null, option types, free from data races)<td> Rust 
-<tr><td>Easy concurrency<td> Go 
+<tr><td>Great performance on par with C and <br>zero cost C interop<td> C, C++, D, Delphi, Rust, Nim, Zig
+<tr><td>Memory safety, immutability, no low-level data races<td> Rust, D
+<tr><td>No null, optional types<td> Rust, Zig
+<tr><td>Easy, scalable concurrency<td> Go 
 <tr><td>Easy cross compilation<td>Go
-<tr><td>Compile time code generation<td>Zig
+<tr><td>Compile time code generation<td>D, Zig
 <tr><td>Small compiler with zero dependencies<td>-
 <tr><td>No global state<td>-
 <tr><td>Hot code reloading<td>-
@@ -111,7 +112,7 @@ V is very similar to Go, and these are the things it improves upon:
 - No GC 
 
 <p>
-- Much faster serialization using codegen and no reflection
+- Much faster serialization using codegen and no runtime reflection
 
 <p>
 - Precompiled HTML templates unlike <code>html/template</code>s that have to be parsed on every request 


### PR DESCRIPTION
D is more popular AFAIK and established than Nim, Zig, and is relevant for V feature overlap, so it seems worth adding to the comparison table.

* Split Safety into memory safety and null safety (as the former is most
important).
* Clarify: low-level data races, scalable concurrency, runtime reflection.
* Zig has optionals.