### PR TITLE
Define 'color' for <code> elements

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -311,6 +311,7 @@ td {
 code {
 	font-family: 'Roboto Mono';
 	background-color: #f0f0f0;
+	color: black;
 	padding: 1px 3px 1px 3px;
 }
 comment {


### PR DESCRIPTION
Reason: The text was not readable because my default color is white, the background color is light grey and the text color was not defined.