### PR TITLE
[docs] Fix propagating errors with optionals

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -1091,8 +1091,7 @@ The amount of work required to "upgrade" a function to an optional function is m
 you have to add a <code>?</code> to the return type and return an error when something goes wrong. 
 <p>
 If you don't need to return an error, you can simply <code>return none</code>. (TODO: <code>none</code> is 
-not implemented yet). Comparing an optional with <code>none</code> is true if the optional contains an
-error or <code>none</code>.
+not implemented yet).
 <p>
 This is the primary way of handling errors in V. They are still values, like in Go,
 but the advantage is that errors can't be unhandled, and handling them is a lot less verbose.
@@ -1105,7 +1104,6 @@ fn wrap_get(url string) ?string {
 	resp := http.get(url)?
 	return resp.body
 }
-assert wrap_get('') == none
 </pre>
 
 <code>http.get</code> returns <code>?http.Response</code>. It was called with 

--- a/docs.html
+++ b/docs.html
@@ -1091,31 +1091,34 @@ The amount of work required to "upgrade" a function to an optional function is m
 you have to add a <code>?</code> to the return type and return an error when something goes wrong. 
 <p>
 If you don't need to return an error, you can simply <code>return none</code>. (TODO: <code>none</code> is 
-not implemented yet). 
+not implemented yet). Comparing an optional with <code>none</code> is true if the optional contains an
+error or <code>none</code>.
 <p>
 This is the primary way of handling errors in V. They are still values, like in Go,
 but the advantage is that errors can't be unhandled, and handling them is a lot less verbose.
 <p>
 
-You can also propagate errors:
+You can also propagate errors (TODO):
 
 <pre>
-resp := http.get(url)?
-println(resp.body)
+fn wrap_get(url string) ?string {
+	resp := http.get(url)?
+	return resp.body
+}
+assert wrap_get('') == none
 </pre>
 
 <code>http.get</code> returns <code>?http.Response</code>. It was called with 
-<code>?</code>, so the error is propagated to the calling function 
-(which must return an optional)  or in case of
-<code>main</code> leads to a panic.
+<code>?</code>, so the error is propagated to the calling function, as
+<code>wrap_get</code> returns an optional. In case of
+<code>main</code>, <code>?</code> leads to a panic.
 
-<p>Basically the code above is a shorter version of
+<p>Basically the line ending in <code>?</code> above is a shorter version of:
 
 <pre>
 resp := http.get(url) or {
-	panic(err)
+	return error(err)
 }
-println(resp.body)
 </pre>
 
 <p>


### PR DESCRIPTION
* `v := get_opt()?` should normally `return error(err)` in the `or` block, not panic.
* ~~Document comparing an optional with `== none` - I used this in the error propagation example, it's marked as TODO (like error propagation).~~

I'm assuming `?` error propagation is a compile error if the containing function does not return an optional, except the docs do say: *in case of main, `?` leads to a panic*.
We should probably remove that because below that it says:
> V does not have a way to force unwrap an optional (like Rust's unwrap() or Swift's !). You have to use or { panic(err) } instead.

If `?` causes a panic then it is a way to force unwrapping.
Also we don't really need a special case just for `main`.
