### PR TITLE
Add `title` attribute for `wip` class

### DIFF
--- a/_layout.html
+++ b/_layout.html
@@ -102,6 +102,7 @@ src='/img/telegram.png'><span class='social-text'>Telegram</span></a>
 <div onclick='set_lang("ru")'>Русский </div> 
 <div onclick='set_lang("zh")'>中文 </div> 
 <div onclick='set_lang("ja")'>日本語</div> 
+<div onclick='set_lang("id")'>Bahasa Indonesia</div> 
 <div style='margin-top:10px'>
 <a target=_blank style='font-size:80%; ' href=
 'https://github.com/vlang/v/wiki/Helping-to-translate-the-V-website'>fix an error/<br>help translate</a> 

--- a/index.html
+++ b/index.html
@@ -638,7 +638,7 @@ row {
 
 <div class='feature first'>
 	<h2 id=ctranslation>%c_translation</h2>
-	V can translate your entire C or C++ <span class='wip'>wip</span> project and offer you the safety, simplicity, and up to 400x compilation speed-up.
+	V can translate your entire C or C++ <span class='wip' title="Work In Progress">wip</span> project and offer you the safety, simplicity, and up to 400x compilation speed-up.
 	<br>
 	<pre style='float:left; font-size:80%;'>
 std::vector&lt;std::string> s;
@@ -676,7 +676,7 @@ but more complicated code won't. C++ is a very complex language, hopefully the p
 
 <div class='feature'>
 <h2 style='height:1px'>&nbsp;</h2>  <!-- i'll never understand css... --> 
-Translating DOOM from C to V and building it in 0.7 seconds (x25 speed-up): <span class='wip'>wip</span>
+Translating DOOM from C to V and building it in 0.7 seconds (x25 speed-up): <span class='wip' title="Work In Progress">wip</span>
 
 <img id='doompic'  src='/img/doom.png'> 
 
@@ -733,9 +733,9 @@ Cross-platform drawing library built on top of GDI+/Cocoa Drawing, and an OpenGL
 for more complex 2D/3D applications, that also has the following features:
 <br> 
 <br> 
-- Loading complex 3D objects with textures <span class='wip'>wip</span> <br> 
-- Camera (moving, looking around) <span class='wip'>wip</span><br> 
-- Skeletal animation <span class='wip'>wip</span> <br> 
+- Loading complex 3D objects with textures <span class='wip' title="Work In Progress">wip</span> <br> 
+- Camera (moving, looking around) <span class='wip' title="Work In Progress">wip</span><br> 
+- Skeletal animation <span class='wip' title="Work In Progress">wip</span> <br> 
 <p>
 DirectX, Vulkan, and Metal support is planned. 
 
@@ -863,7 +863,7 @@ V can call C code, and calling V code is possible in any language that has C int
 
 
 <div class='feature'>
-	<h2>V Script <span class='wip'>wip</span></h2>
+	<h2>V Script <span class='wip' title="Work In Progress">wip</span></h2>
 	<pre>
 #v 
 for file in ls('build/') {


### PR DESCRIPTION
#### Add the `title` attribute to elements with the `wip` class (in other words, this is a tooltip). 

This is very useful for accessibility. Users will know that what the heck is that? when they hover on that element.