### PR TITLE
SCSS: improved monospace

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -64,10 +64,10 @@ p {
 	}
 }
 pre {
-	font-family: "Roboto Mono", "Courier New", Menlo;
+	font-family: "Roboto Mono", "Courier New", Menlo, "DejaVu Sans Mono", Monaco, Courier, monospace;
 	@include mobile {
 		overflow: scroll;
-		font-size: 11px;
+		font-size: 12px;
 	}
 }
 #donate {


### PR DESCRIPTION
extended monospace into Linux, old OSX,
+1px <pre> font size

Harder to read, especially on mobile.

IMHO should use em for fontsizes.