### PR TITLE
Fixed typo on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@ Or build V from source with a C compiler:
 <pre class='hello_devs' id=ex2 style='display:none'>
 <key>import</key> os
 
-<comment>// Print file lines that starth with "DEBUG:"</comment>
+<comment>// Print file lines that start with "DEBUG:"</comment>
 <key>fn</key> main() {
 	<comment>// `read_file` returns an optional (`?string`), it must be checked</comment>
 	text := os.read_file(<str>'app.log'</str>) <key>or</key> {


### PR DESCRIPTION
fixed typo "starth" on the homepage for the code example of reading lines from a file