### PR TITLE
Fix a bug in vlang.io/docs#maps

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -466,7 +466,7 @@ m.delete(<str>'two'</str>)
 
 numbers := { 
 	<str>'one'</str>: 1,
-	<str>'two'</str>: 2,
+	<str>'two'</str>: 2
 } 
 </pre> 
 


### PR DESCRIPTION
Remove unnecessary semicolon in example code.

If there is a semicolon at the end of the map element, a compilation error will occur.