### PR TITLE
FIXED: typo

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -523,7 +523,7 @@ m.delete(<str>'two'</str>)
 
 numbers := {
 	<str>'one'</str>: 1,
-	<str>'two'</str>: 2,
+	<str>'two'</str>: 2
 }
 </pre>
 


### PR DESCRIPTION
The last comma must be removed to avoid `syntax error: unexpected }, expecting STR`