### PR TITLE
Added emacs icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@ if (macosPlatforms.indexOf(platform) !== -1 || iosPlatforms.indexOf(platform) !=
 
     &nbsp; &nbsp; &nbsp;
 
+    <a target=_blank href='https://github.com/damon-kwok/v-mode'><img width=27 src='/img/emacs.png'></a>
     <a target=_blank href='https://marketplace.visualstudio.com/items?itemName=0x9ef.vscode-vlang'><img width=27 src='/img/vscode.png'></a>
     <a target=_blank href='https://github.com/ollykel/v-vim'><img width=27 src='/img/vim.png'></a>
     <a target=_blank href='https://github.com/oversoul/vlang-sublime'><img width=27 src='/img/sublime.png'></a>


### PR DESCRIPTION
Added `Emacs` icon to website.

- Emacs Icon
[https://www.gnu.org/software/emacs/images/emacs.png](https://www.gnu.org/software/emacs/images/emacs.png)

- Emacs26 Icon
![emacs26](https://user-images.githubusercontent.com/1702133/88056650-78784380-cb93-11ea-84ba-e511b7ddee9c.png)

- SVG badge
https://simpleicons.org/?q=emacs