### PR TITLE
Remove freenode link

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,8 +102,6 @@ if (macosPlatforms.indexOf(platform) !== -1 || iosPlatforms.indexOf(platform) !=
       <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="twitch" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-twitch fa-w-16 fa-2x"><path fill="currentColor" d="M391.17,103.47H352.54v109.7h38.63ZM285,103H246.37V212.75H285ZM120.83,0,24.31,91.42V420.58H140.14V512l96.53-91.42h77.25L487.69,256V0ZM449.07,237.75l-77.22,73.12H294.61l-67.6,64v-64H140.14V36.58H449.07Z" class=""></path></svg>
     </a>
 
-    <a href='#' onclick='alert("irc.freenode.net #vlang")'><img style='width:25px; position:relative; top:-5px' src='/img/irc.png'></a>
-
     &nbsp; &nbsp; &nbsp;
 
     <a target=_blank href='https://marketplace.visualstudio.com/items?itemName=vlanguage.vscode-vlang'><img width=27 src='/img/vscode.png'></a>


### PR DESCRIPTION
Unfortunately, Freenode has fallen into malicious hands. For more info, see http://kline.sh/. This PR removes the IRC link on the website.