### PR TITLE
More correct comparison between vlang and Rust

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -36,14 +36,15 @@ features:
 </p>
 <table>
 <tr><td style='width:300px'>Fast compilation<td style='width:200px'> D, Go, Delphi
-<tr><td>Simplicity & maintainability<td>Go
+<tr><td>Simplicity<td>Go
+<tr><td>Maintainability<td>Rust
 <tr><td>Great performance on par with C and <br>zero cost C interop<td> C, C++, D, Delphi, Rust
 <tr><td>Safety (immutability, no null, option types, free from data races)<td> Rust
-<tr><td>Easy concurrency<td> Go
-<tr><td>Easy cross compilation<td>Go
-<tr><td>Compile time code generation<td>D
+<tr><td>Easy concurrency<td> Go, Rust
+<tr><td>Easy cross compilation<td>Go, Rust
+<tr><td>Compile time code generation<td>D, Rust
 <tr><td>Small compiler with zero dependencies<td>-
-<tr><td>No global state<td>-
+<tr><td>No global state<td> Rust
 <tr><td>Hot code reloading<td>-
 </table>
 


### PR DESCRIPTION
I propose the following changes to the vlang website:

- simplicity is not correlated with maintainability, there should be two separate columns
for example, lua is very simple but also hard to maintain, given its lack of features
- Rust's advanced features make it more maintainable, despite its lack of simplicity
- Rust has "Easy concurrency", it's significantly easier and safer than C or C++, source: https://doc.rust-lang.org/book/ch16-00-concurrency.html

>  By leveraging ownership and type checking, many concurrency errors are compile-time errors in Rust rather than runtime errors. Therefore, rather than making you spend lots of time trying to reproduce the exact circumstances under which a runtime concurrency bug occurs, incorrect code will refuse to compile and present an error explaining the problem.

- Rust has "Easy cross compilation" with cargo cross, it's as easy as using normal cargo: https://github.com/rust-embedded/cross

> cross has the exact same CLI as Cargo but as it relies on Docker you'll have to start the daemon before you can use it.

- Rust has "Compile time code generation": https://doc.rust-lang.org/reference/procedural-macros.html 

> Procedural macros allow you to run code at compile time that operates over Rust syntax, both consuming and producing Rust syntax. You can sort of think of procedural macros as functions from an AST to another AST.

- Rust basically has "No global state": it's possible to have a global state, but it's heavily discouraged by the type system and the borrow checker, **rustc won't compile if you have a global non synchronized mutable state**, you have to explicitly synchronize or use unsafe {}