### PR TITLE
Use body instead of text

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -330,7 +330,7 @@ mut:
 
 fn main() {
 	resp := http.get(stories_url) ?
-	ids := json.decode([]int, resp.text) ?
+	ids := json.decode([]int, resp.body) ?
 	shared cursor := Cursor{}
 	mut threads := []thread{}
 
@@ -345,7 +345,7 @@ fn main() {
 					ids[cursor.pos - 1]
 				}
 				resp := http.get('$item_base_url/${id}.json') or { panic(err) }
-				story := json.decode(Story, resp.text) or { panic(err) }
+				story := json.decode(Story, resp.body) or { panic(err) }
 				println(story.title)
 			}
 		}(ids, shared cursor)

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@ resp := http.get('https://vlang.io/utc_now') or {
     println('failed to fetch data from the server')
     return
 }
-t := time.unix(resp.text.int())
+t := time.unix(resp.body.int())
 println(t.format()) // 2019-08-16 17:48
 </pre>
   <pre class="hello_devs" id=ex4 style='display:none'>
@@ -699,7 +699,7 @@ v install ui
       <pre style="margin-right: 36px">v
 >>> import net.http
 >>> data := http.get('https://vlang.io/utc_now')?
->>> data.text
+>>> data.body
 1565977541</pre>
     </div>
     <div class="block">

--- a/preview.html
+++ b/preview.html
@@ -231,7 +231,7 @@ resp := http.get('https://vlang.io/utc_now') or {
     println('failed to fetch data from the server')
     return
 }
-t := time.unix(resp.text.int())
+t := time.unix(resp.body.int())
 println(t.format()) // 2019-08-16 17:48
 </pre>
   <pre class="hello_devs" id=ex4 style='display:none'>
@@ -742,7 +742,7 @@ v install ui
       <pre style="margin-right: 36px">v
 >>> import net.http
 >>> data := http.get('https://vlang.io/utc_now')?
->>> data.text
+>>> data.body
 1565977541</pre>
     </div>
     <div class="block">


### PR DESCRIPTION
`text` will be deprecated after 2022-10-03.
So, use Response.body instead.