### PR TITLE
Fix the layout on smartphones

### DIFF
--- a/app.css
+++ b/app.css
@@ -730,9 +730,14 @@ textarea:focus {
 	top: -5px
 }
 
-.landing .section .block pre {
+.landing .section .block pre,
+.landing .section .block code {
 	white-space: pre-wrap;
 	word-break: break-word
+}
+
+.landing .section .block img {
+	max-width: 100%
 }
 
 .landing ul {
@@ -930,7 +935,8 @@ position:absolute; right:0px; top:50px; text-align:center; display:block; width:
 	flex-direction: column;
 }
 .news .container {
-	display: flex
+	display: flex;
+	flex-wrap: wrap
 }
 .news_header{
 	text-align:center;


### PR DESCRIPTION
Prevent horizontal overflow of some elements by letting them wrap or by shrinking their width.

From this:

![obrazek](https://github.com/vlang/website/assets/733193/d10d91fa-2e2a-40e0-955a-c0f6a181390b)

To this:

![obrazek](https://github.com/vlang/website/assets/733193/72af49f2-a8dd-4fee-b52a-ea5baa71cb1f)
